### PR TITLE
Fix typo in interp-R0 error

### DIFF
--- a/interp-R0.rkt
+++ b/interp-R0.rkt
@@ -18,7 +18,7 @@
       [(Prim 'read '())
        (define r (read))
        (cond [(fixnum? r) r]
-             [else (error 'interp-R1 "expected an integer" r)])]
+             [else (error 'interp-R0 "expected an integer" r)])]
       [(Prim '- (list e))
        (define v (interp-exp e))
        (fx- 0 v)]
@@ -32,5 +32,3 @@
   (match p
     [(Program info e) (interp-exp e)]
     ))
-
-


### PR DESCRIPTION
This PR corrects a typo in the error call for `interp-R0`.

Related PRs
* https://github.com/IUCompilerCourse/Essentials-of-Compilation/pull/42